### PR TITLE
Fix: Options > Music toggle doesn't stop currently playing music (MUSIC_TSF build)

### DIFF
--- a/SpaceCadetPinball/midi.cpp
+++ b/SpaceCadetPinball/midi.cpp
@@ -124,6 +124,11 @@ int midi::music_stop()
 
 #ifdef MUSIC_SDL
 	return Mix_HaltMusic();
+#elif defined(MUSIC_TSF)
+	tsf_note_off_all(tsfSynth);
+	currentMessage = nullptr;
+	midiTime = 0.0f;
+	return 1;
 #else
 	return 0;
 #endif


### PR DESCRIPTION
`midi::music_stop()` has a `MUSIC_SDL` branch that calls `Mix_HaltMusic()`, but no `MUSIC_TSF` branch — it falls through to the `#else` and does nothing. Toggling `Music` off in the in-game Options menu correctly flips `Options.Music` (via `options::toggle`) and prevents music from starting on the next game, but has no effect on whatever's already playing when built with `MUSIC_TSF`.

Fix mirrors the existing `MUSIC_TSF` handling already in this same file for Full Tilt tables (`stop_ft()` / `music_shutdown_ft()`): `tsf_note_off_all()` plus resetting the sequencer position (`currentMessage`/`midiTime`).

Found while embedding this project's browser build in a Windows 98 desktop recreation — the Options > Music checkbox visibly had no effect on already-playing audio until this fix. Verified the fix is logically symmetric with the already-working Full Tilt TSF stop path in the same file; I don't have an Emscripten toolchain set up to produce a fresh build for a live before/after, so please double check on your end before merging.